### PR TITLE
Change Adafruit github link from ssh to https

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='philble',
       packages=['philble'],
       install_requires=[
           # Version from pip doesn't work on macOS Mojave
-          'Adafruit_BluefruitLE @ git+ssh://git@github.com/adafruit/Adafruit_Python_BluefruitLE'
+          'Adafruit_BluefruitLE @ git+https://git@github.com/adafruit/Adafruit_Python_BluefruitLE'
           ],
       zip_safe=False)


### PR DESCRIPTION
This makes installation work without having to setup ssh first