### PR TITLE
Allow discovery to proceed when list of found devices doesn't match expected

### DIFF
--- a/philble/discover.py
+++ b/philble/discover.py
@@ -4,6 +4,11 @@ import os
 unbuffered = os.fdopen(sys.stdout.fileno(), 'wb', 0)
 MAX_TICKS = 40
 
+HUE_DEVICE_NAMES = frozenset([
+    'Hue Lamp',
+    'Hue ambiance lamp',
+])
+
 def discover(ble, config):
     unbuffered.write(b'Discovering')
     ble.clear_cached_data()
@@ -13,22 +18,30 @@ def discover(ble, config):
     adapter.power_on()
     adapter.start_scan()
 
-    found = False
     for _ in range(MAX_TICKS):
         unbuffered.write(b'.')
         time.sleep(.5)
-        lights = [dev for dev in ble.find_devices() if dev.name == 'Hue Lamp']
+        lights = [dev for dev in ble.find_devices() if dev.name in HUE_DEVICE_NAMES]
         if len(lights) == len(config):
-            found = True
             break
 
-    if found:
-        print('ok')
-        for light in lights:
-            light.connect()
-    else:
-        print('fail')
+    if len(lights) == 0:
         raise SystemExit
 
+    new_lights = 0
+    names = dict()
+
+    print('found %d lights:' % len(lights))
+    for light in lights:
+        if light.id in config:
+            name = config[light.id]
+        else:
+            new_lights += 1
+            name = "new_%d" % new_lights
+
+        names[name] = light
+        print("%s (%s %s)" % (name, light.name, light.id))
+        light.connect()
+
     time.sleep(.5)
-    return {config[light.id]:light for light in lights}
+    return names


### PR DESCRIPTION
As the name suggests. New devices are given names `new_N`. Missing devices don't cause trouble. Also add Hue Ambiance as a valid device name.

Example:
```
> ./lightcom
Edit config.py to set up your own lights...
Discovering........................................found 1 lights:
new_1 (Hue ambiance lamp 3a602fd5-e3dc-48d3-930a-852a5db9ade5)
LIGHT COMMANDER
Lights (l) =  .new_1, .all
Python 3.7.3 (default, Apr 24 2020, 18:51:23)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: l.new_1.power(False)
Out[1]: <philble.client.Client at 0x10b47aac8>
```