### PR TITLE
Change Bluefruit library for recent Bluez versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='philble',
       packages=['philble'],
       install_requires=[
           # Version from pip doesn't work on macOS Mojave
-          'Adafruit_BluefruitLE @ git+https://git@github.com/adafruit/Adafruit_Python_BluefruitLE'
+          'Adafruit_BluefruitLE @ git+https://github.com/donatieng/Adafruit_Python_BluefruitLE''
           ],
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(name='philble',
       packages=['philble'],
       install_requires=[
           # Version from pip doesn't work on macOS Mojave
-          'Adafruit_BluefruitLE @ git+https://github.com/donatieng/Adafruit_Python_BluefruitLE''
+          # Adafruit version doesn't work on modern Linux
+          'Adafruit_BluefruitLE @ git+https://github.com/donatieng/Adafruit_Python_BluefruitLE'
           ],
       zip_safe=False)


### PR DESCRIPTION
Recent (2018+?) versions of the Linux Bluez library/stack don't work with the official Adafruit lib anymore, and since the Bluefruit lib is officially deprecated, there won't be an update. I found that this version here works (Bluez 5.55 on Linux 5.10/Debian sid). 

I have not tested this on MacOS or anything.